### PR TITLE
Fix `Asset.UnmarshallBinary` not working

### DIFF
--- a/channel/asset.go
+++ b/channel/asset.go
@@ -92,7 +92,7 @@ func (a Asset) MapKey() AssetMapKey {
 // MarshalBinary marshals the asset into its binary representation.
 func (a Asset) MarshalBinary() ([]byte, error) {
 	var buf bytes.Buffer
-	err := perunio.Encode(&buf, &a.AssetHolder, a.ChainID)
+	err := perunio.Encode(&buf, a.ChainID, &a.AssetHolder)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func (a Asset) MarshalBinary() ([]byte, error) {
 }
 
 // UnmarshalBinary unmarshals the asset from its binary representation.
-func (a Asset) UnmarshalBinary(data []byte) error {
+func (a *Asset) UnmarshalBinary(data []byte) error {
 	buf := bytes.NewBuffer(data)
 	return perunio.Decode(buf, &a.ChainID, &a.AssetHolder)
 }

--- a/channel/asset_test.go
+++ b/channel/asset_test.go
@@ -16,6 +16,7 @@ package channel_test
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -123,4 +124,21 @@ func Test_Asset_GenericMarshaler(t *testing.T) {
 		asset := ethwallettest.NewRandomAddress(rng)
 		wiretest.GenericMarshalerTest(t, &asset)
 	}
+}
+
+func TestMarshalling(t *testing.T) {
+	rng := pkgtest.Prng(t)
+	assetIn := ethchannel.Asset{
+		ChainID: ethchannel.ChainID{
+			big.NewInt(rng.Int63()),
+		},
+		AssetHolder: ethwallettest.NewRandomAddress(rng),
+	}
+	bytes, err := assetIn.MarshalBinary()
+	require.NoError(t, err)
+	var assetOut ethchannel.Asset
+	err = assetOut.UnmarshalBinary(bytes)
+	require.NoError(t, err)
+
+	require.Equal(t, assetIn, assetOut)
 }


### PR DESCRIPTION
- The method did not have a pointer receiver and thus could not set the value, resulting in the previous (default) value instead of the just unmarshalled one.
- Additionally, the order was different from `Asset.MarshallBinary`, which meant unmarshalling a value just marshalled would result in the wrong value or an error.

The added test coveres both these cases.

Signed-off-by: Jens Winkle <jens@perun.network>