### PR TITLE
Go perun update

### DIFF
--- a/channel/app.go
+++ b/channel/app.go
@@ -2,6 +2,10 @@ package channel
 
 import (
 	ethwallet "github.com/perun-network/perun-eth-backend/wallet"
+	ethtestwallet "github.com/perun-network/perun-eth-backend/wallet/test"
+
+	"math/rand"
+
 	"perun.network/go-perun/channel"
 )
 
@@ -12,7 +16,7 @@ type AppID struct {
 }
 type AppIDKey string
 
-func (a *AppID) Equal(b channel.AppID) bool {
+func (a AppID) Equal(b channel.AppID) bool {
 	bTyped, ok := b.(*AppID)
 	if !ok {
 		return false
@@ -30,8 +34,8 @@ func (id AppID) Key() channel.AppIDKey {
 
 }
 
-func (a *AppID) MarshalBinary() ([]byte, error) {
-	data, err := a.Address.MarshalBinary() // Access the embedded Address field
+func (a AppID) MarshalBinary() ([]byte, error) {
+	data, err := a.Address.MarshalBinary()
 
 	if err != nil {
 		return nil, err
@@ -46,6 +50,11 @@ func (a *AppID) UnmarshalBinary(data []byte) error {
 		return err
 	}
 	appaddr := &AppID{addr}
-	*a = *appaddr // Dereference the addr pointer before assigning it to *a
+	*a = *appaddr
 	return nil
+}
+
+func NewRandomAppID(rng *rand.Rand) *AppID {
+	addr := ethtestwallet.NewRandomAddress(rng)
+	return &AppID{&addr}
 }

--- a/channel/app.go
+++ b/channel/app.go
@@ -1,0 +1,48 @@
+package channel
+
+import (
+	"bytes"
+	ethwallet "github.com/perun-network/perun-eth-backend/wallet"
+	"perun.network/go-perun/channel"
+	"perun.network/go-perun/wire/perunio"
+)
+
+var _ channel.AppID = new(AppID)
+
+type AppID struct {
+	*ethwallet.Address
+}
+type AppIDKey string
+
+func (id AppID) Equal(b channel.AppID) bool {
+	bTyped, ok := b.(*AppID)
+	if !ok {
+		return false
+	}
+
+	return id.Address.Equal(bTyped.Address)
+}
+
+// Key returns the key representation of this app identifier.
+func (id AppID) Key() channel.AppIDKey {
+	b, err := id.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	return channel.AppIDKey(b)
+}
+
+func (a AppID) MarshalBinary() ([]byte, error) {
+	var buf bytes.Buffer
+	err := perunio.Encode(&buf, &a)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// UnmarshalBinary unmarshals the asset from its binary representation.
+func (a *AppID) UnmarshalBinary(data []byte) error {
+	buf := bytes.NewBuffer(data)
+	return perunio.Decode(buf, &a)
+}

--- a/channel/backend.go
+++ b/channel/backend.go
@@ -91,6 +91,11 @@ func (*Backend) CalcID(p *channel.Params) (id channel.ID) {
 	return CalcID(p)
 }
 
+func (b *Backend) NewAppID() channel.AppID {
+	addr := &ethwallet.Address{}
+	return &AppID{addr}
+}
+
 // Sign signs the channel state as needed by the ethereum smart contracts.
 func (*Backend) Sign(acc wallet.Account, s *channel.State) (wallet.Sig, error) {
 	return Sign(acc, s)
@@ -152,7 +157,8 @@ func Verify(addr wallet.Address, s *channel.State, sig wallet.Sig) (bool, error)
 func ToEthParams(p *channel.Params) adjudicator.ChannelParams {
 	var app common.Address
 	if p.App != nil && !channel.IsNoApp(p.App) {
-		app = ethwallet.AsEthAddr(p.App.Def())
+		appAddr := p.App.Def().(*AppID).Address
+		app = ethwallet.AsEthAddr(appAddr)
 	}
 
 	return adjudicator.ChannelParams{

--- a/channel/conclude.go
+++ b/channel/conclude.go
@@ -164,7 +164,7 @@ func (a *Adjudicator) waitConcludedSecondary(ctx context.Context, req channel.Ad
 	// In final Register calls, as the non-initiator, we optimistically wait for
 	// the other party to send the transaction first for
 	// `secondaryWaitBlocks + TxFinalityDepth` many blocks.
-	if req.Tx.IsFinal && req.Secondary {
+	if req.Tx.IsFinal {
 		// Create subscription.
 		sub, events, subErr, err := a.createEventSub(ctx, req.Tx.ID, false)
 		if err != nil {

--- a/channel/conclude_test.go
+++ b/channel/conclude_test.go
@@ -80,13 +80,14 @@ func testConcludeFinal(t *testing.T, numParts int) {
 				Acc:       s.Accs[i],
 				Idx:       channel.Index(i),
 				Tx:        tx,
-				Secondary: (i != initiator),
+				//Secondary: (i != initiator),
 			}
+			secondary := (i != initiator)
 			diff, err := test.NonceDiff(s.Accs[i].Address(), s.Adjs[i], func() error {
 				return s.Adjs[i].Register(ctx, req, nil)
 			})
 			require.NoError(t, err, "Withdrawing should succeed")
-			if !req.Secondary {
+			if !secondary {
 				// The Initiator must send a TX.
 				require.Equal(t, diff, 1)
 			} else {
@@ -258,7 +259,7 @@ func register(ctx context.Context, adj *test.SimAdjudicator, accounts []*keystor
 		Acc:       accounts[0],
 		Idx:       0,
 		Tx:        tx,
-		Secondary: false,
+		//Secondary: false,
 	}
 	return adj.Register(ctx, req, sub)
 }
@@ -281,7 +282,7 @@ func withdraw(ctx context.Context, adj *test.SimAdjudicator, accounts []*keystor
 			Acc:       a,
 			Idx:       channel.Index(i),
 			Tx:        tx,
-			Secondary: i != 0,
+			//Secondary: i != 0,
 		}
 
 		if err := adj.Withdraw(ctx, req, subStates); err != nil {

--- a/channel/contractbackend.go
+++ b/channel/contractbackend.go
@@ -152,6 +152,7 @@ func (c *ContractBackend) NewTransactor(ctx context.Context, gasLimit uint64, ac
 	if err != nil {
 		return nil, err
 	}
+	log.Printf("Nonce: %d", nonce)
 	auth.Nonce = big.NewInt(int64(nonce))
 	return auth, nil
 }

--- a/channel/subscription.go
+++ b/channel/subscription.go
@@ -183,7 +183,14 @@ func (a *Adjudicator) convertEvent(ctx context.Context, e *adjudicator.Adjudicat
 		if ch.Params.App == zeroAddress {
 			app = channel.NoApp()
 		} else {
-			app, err = channel.Resolve(wallet.AsWalletAddr(ch.Params.App))
+
+			appAddr := wallet.AsWalletAddr(ch.Params.App)
+			appID := &AppID{
+				Address: appAddr,
+			}
+			
+			app, err = channel.Resolve(appID)
+
 			if err != nil {
 				return nil, err
 			}
@@ -201,7 +208,12 @@ func (a *Adjudicator) convertEvent(ctx context.Context, e *adjudicator.Adjudicat
 		if err != nil {
 			return nil, errors.WithMessage(err, "fetching call data")
 		}
-		app, err := channel.Resolve(wallet.AsWalletAddr(args.Params.App))
+		appAddr:= wallet.AsWalletAddr(args.Params.App)
+		appID := &AppID{
+			Address: appAddr,
+		}
+		app, err := channel.Resolve(appID)
+
 		if err != nil {
 			return nil, errors.WithMessage(err, "resolving app")
 		}

--- a/channel/test/init.go
+++ b/channel/test/init.go
@@ -15,9 +15,15 @@
 package test
 
 import (
+	"github.com/perun-network/perun-eth-backend/channel"
+	"math/rand"
+	pchannel "perun.network/go-perun/channel"
 	"perun.network/go-perun/channel/test"
 )
 
 func init() {
 	test.SetRandomizer(new(randomizer))
+	test.SetNewRandomAppID(func(r *rand.Rand) pchannel.AppID {
+		return channel.NewRandomAppID(r)
+	})
 }

--- a/channel/withdraw.go
+++ b/channel/withdraw.go
@@ -146,11 +146,11 @@ func (a *Adjudicator) callAssetWithdraw(ctx context.Context, request channel.Adj
 		if err != nil {
 			return nil, errors.WithMessagef(err, "creating transactor for asset %d", asset.assetIndex)
 		}
-
+		log.Printf("Withdrawal nonce: %d\n", trans.Nonce)
 		tx, err := asset.Withdraw(trans, auth, sig)
 		if err != nil {
 			err = cherrors.CheckIsChainNotReachableError(err)
-			return nil, errors.WithMessagef(err, "withdrawing asset %d", asset.assetIndex)
+			return nil, errors.WithMessagef(err, "withdrawing asset %d with nonce %d", asset.assetIndex, trans.Nonce)
 		}
 		log.Debugf("Sent transaction %v", tx.Hash().Hex())
 		return tx, nil

--- a/client/app_test.go
+++ b/client/app_test.go
@@ -45,7 +45,9 @@ func TestProgression(t *testing.T) {
 	}
 
 	appAddress := deployMockApp(t, backendSetup)
-	app := channel.NewMockApp(appAddress)
+	appAddrBackend := appAddress.(*ethwallet.Address)
+	appID := &ethchannel.AppID{Address: appAddrBackend}
+	app := channel.NewMockApp(appID)
 	channel.RegisterApp(app)
 
 	execConfig := &clienttest.ProgressionExecConfig{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/perun-network/perun-eth-backend
 
-go 1.17
+go 1.19
 
 require (
 	github.com/ethereum/go-ethereum v1.10.12
@@ -9,7 +9,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	perun.network/go-perun v0.10.6
+	perun.network/go-perun v0.10.7-0.20230316162856-6163e2034459
 	polycry.pt/poly-go v0.0.0-20220301085937-fb9d71b45a37
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	perun.network/go-perun v0.10.5
+	perun.network/go-perun v0.10.6
 	polycry.pt/poly-go v0.0.0-20220301085937-fb9d71b45a37
 )
 

--- a/go.sum
+++ b/go.sum
@@ -80,7 +80,6 @@ github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOC
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -397,13 +396,11 @@ github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
-go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -472,7 +469,6 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d h1:20cMwl2fHAzkJMEA+8J4JgqBQcQGzbisXo31MIeenXI=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -524,10 +520,8 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210420205809-ac73e9fd8988/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912 h1:uCLL3g5wH2xjxVREVuAbP9JM5PPKjRbXKRa6IBjkzmU=
 golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -571,7 +565,6 @@ golang.org/x/tools v0.0.0-20191216173652-a0e659d51361/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200108203644-89082a384178/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -651,9 +644,8 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
-perun.network/go-perun v0.10.6 h1:uj1e33yfCSfE75DK/uwjNp+TwvGG85Qhi6HuYQ9EPrQ=
-perun.network/go-perun v0.10.6/go.mod h1:BGBZC3npkX457u87pjDd0NEIXr1a4dsH4H/YpLdGGe8=
-polycry.pt/poly-go v0.0.0-20220222131629-aa4bdbaab60b/go.mod h1:XUBrNtqgEhN3EEOP/5gh7IBd3xVHKidCjXDZfl9+kMU=
+perun.network/go-perun v0.10.7-0.20230316162856-6163e2034459 h1:NAZEFlyebkfSiaw40ZHXm1FOz8AOR7DdPUaqB+WHFUo=
+perun.network/go-perun v0.10.7-0.20230316162856-6163e2034459/go.mod h1:BGBZC3npkX457u87pjDd0NEIXr1a4dsH4H/YpLdGGe8=
 polycry.pt/poly-go v0.0.0-20220301085937-fb9d71b45a37 h1:iA5GzEa/hHfVlQpimEjPV09NATwHXxSjWNB0VVodtew=
 polycry.pt/poly-go v0.0.0-20220301085937-fb9d71b45a37/go.mod h1:XUBrNtqgEhN3EEOP/5gh7IBd3xVHKidCjXDZfl9+kMU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/go.sum
+++ b/go.sum
@@ -651,8 +651,8 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
-perun.network/go-perun v0.10.5 h1:bIaAoLLh8R+RXdPh+MkCJcbtumsFkNvoVAJwb60JKjg=
-perun.network/go-perun v0.10.5/go.mod h1:BGBZC3npkX457u87pjDd0NEIXr1a4dsH4H/YpLdGGe8=
+perun.network/go-perun v0.10.6 h1:uj1e33yfCSfE75DK/uwjNp+TwvGG85Qhi6HuYQ9EPrQ=
+perun.network/go-perun v0.10.6/go.mod h1:BGBZC3npkX457u87pjDd0NEIXr1a4dsH4H/YpLdGGe8=
 polycry.pt/poly-go v0.0.0-20220222131629-aa4bdbaab60b/go.mod h1:XUBrNtqgEhN3EEOP/5gh7IBd3xVHKidCjXDZfl9+kMU=
 polycry.pt/poly-go v0.0.0-20220301085937-fb9d71b45a37 h1:iA5GzEa/hHfVlQpimEjPV09NATwHXxSjWNB0VVodtew=
 polycry.pt/poly-go v0.0.0-20220301085937-fb9d71b45a37/go.mod h1:XUBrNtqgEhN3EEOP/5gh7IBd3xVHKidCjXDZfl9+kMU=


### PR DESCRIPTION
The changes restore compatibility between the core Perun framework and the Ethereum backend. The AppID type that has been introduced in [https://github.com/hyperledger-labs/go-perun/commit/c23f66bcb91dd71ff6c24acb37adb2928bfee96a](url), was implemented in the Ethereum backend to adapt to these changes. Further, the deprecated "Secondary" field in the channel.Adjudicator type ([https://github.com/hyperledger-labs/go-perun/commit/be6e07257c123309c98fbbea4b86440275be2797](url)) has also been removed in the backend.