### PR TITLE
Go-Ethereum 1.11.3 compatibility (no version bump)

### DIFF
--- a/channel/test/simulated.go
+++ b/channel/test/simulated.go
@@ -222,7 +222,7 @@ func (s *SimulatedBackend) Reorg(ctx context.Context, depth uint64, reorder Reor
 	defer s.sbMtx.Unlock()
 
 	// parent at current - depth.
-	parentN := new(big.Int).Sub(s.Blockchain().CurrentBlock().Number(), big.NewInt(int64(depth)))
+	parentN := new(big.Int).Sub(s.Blockchain().CurrentHeader().Number, big.NewInt(int64(depth)))
 	parent, err := s.BlockByNumber(ctx, parentN)
 	if err != nil {
 		return errors.Wrap(err, "retrieving reorg parent")


### PR DESCRIPTION
Go-Ethereum 1.11.3 changes how `BlockChain.CurrentBlock()` works: Instead of returning a `*types.Block` it returns a `*types.Header`. This commit changes it to use `BlockChain.CurrentHeader()`, which is sufficient for us and will not break when bumping Go-Ethereum to version 1.11.3.