### PR TITLE
feat(wire): add ecdsa authentication to wire

### DIFF
--- a/wallet/address.go
+++ b/wallet/address.go
@@ -70,7 +70,9 @@ func (a *Address) Equal(addr wallet.Address) bool {
 }
 
 // Cmp checks ordering of two addresses.
-//  0 if a==b,
+//
+//	0 if a==b,
+//
 // -1 if a < b,
 // +1 if a > b.
 // https://godoc.org/bytes#Compare

--- a/wire/doc.go
+++ b/wire/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2024 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package wire contains a simplistic implementation of the perun wire's
+// account, and address interfaces.
+// An account can be instantiated directly with a random secret key.
+// The account and address offer Handshake Authentication through Go-Perun Wire.
+package wire // import "github.com/perun-network/perun-eth-backend/wire"

--- a/wire/wire_test.go
+++ b/wire/wire_test.go
@@ -1,0 +1,45 @@
+// Copyright 2024 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wire_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/perun-network/perun-eth-backend/wire"
+	"github.com/stretchr/testify/assert"
+	perunwire "perun.network/go-perun/wire"
+	"perun.network/go-perun/wire/test"
+	pkgtest "polycry.pt/poly-go/test"
+)
+
+var dataToSign = []byte("SomeLongDataThatShouldBeSignedPlease")
+
+func TestAddress(t *testing.T) {
+	test.TestAddressImplementation(t, func() perunwire.Address {
+		return wire.NewAddress()
+	}, func(rng *rand.Rand) perunwire.Address {
+		return wire.NewRandomAddress(rng)
+	})
+}
+func TestSignatures(t *testing.T) {
+	acc := wire.NewRandomAccount(pkgtest.Prng(t))
+	sig, err := acc.Sign(dataToSign)
+	assert.NoError(t, err, "Sign with new account should succeed")
+	assert.NotNil(t, sig)
+	assert.Equal(t, len(sig), wire.SigLen, "Ethereum signature has wrong length")
+	err = acc.Address().Verify(dataToSign, sig)
+	assert.NoError(t, err, "Verification should succeed")
+}


### PR DESCRIPTION
# Wire Identity Authentication

## Description
This PR aims to add the ECDSA cryptographic authentication feature to the `wire`'s implementation of perun-eth-backend. The cryptographic key pair is ECDSA, with a signature length of 65, taking inspiration from the wallet implementation of perun-eth-backend. This implementation must be in sync with the wire interface of go-perun 1.11.

### Location: `wire` package
