### PR TITLE
chore: update action cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Restore dependencies from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build
@@ -90,7 +90,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Restore dependencies from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build


### PR DESCRIPTION
### What does this PR do?
Updates to the latest actions cache.

### Where should the reviewer start?

Check that actions/cache@v4 works for you.

### Why is it needed?

Per [GitHub](https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/) versions 1 and 2 will go offline 01 FEB 2025.

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.
